### PR TITLE
Decouple builder from framework image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 
 .idea/
+
+_out/

--- a/README.md
+++ b/README.md
@@ -2,18 +2,14 @@
 
 # Checkup's Launcher
 ## Build Instructions
-1. Build the image:
 ```bash
-$ cd checkup-launcher
-$ ./build-image
-```
+# build checkup-framework image
+$ build/build-image
 
-Note: you can use other container engine to build the image, for example:
-```bash
-$ cd checkup-launcher
-$ CRI=docker ./build-image
+# override CRI to use different container runtime
+$ CRI=docker 
+$ build/build-image
 ```
-2. The result shall be an image tagged: `checkup-launcher:latest`
 
 ## Deployment Instructions
 1. Push the built image to a registry of your choice.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,10 +1,7 @@
-FROM golang:1.17.7-alpine3.15
+FROM alpine:3.15.0
 
-WORKDIR /usr/src/checkup-launcher
+RUN apk add --no-cache libc6-compat
 
-COPY . .
-RUN go mod verify
+COPY checkup-framework /usr/local/bin
 
-RUN go build -v -o /usr/local/bin/checkup-launcher
-
-ENTRYPOINT checkup-launcher
+ENTRYPOINT checkup-framework

--- a/build/build-image
+++ b/build/build-image
@@ -1,8 +1,54 @@
 #!/usr/bin/env bash
 
+# Notes:
+# [-]  In case podman is being used and the following error occurs
+#         WARN[0012] error mounting subscriptions, skipping entry in /usr/share/containers/mounts.conf:
+#         getting host subscription data: failed to read subscriptions from "/usr/share/rhel/secrets":
+#         open /usr/share/rhel/secrets/rhsm/rhsm.conf: permission denied
+#      Consider creating an empty 'mounts.conf' file workaround ('touch ~/.config/containers/mounts.conf)'
+#      https://bugzilla.redhat.com/show_bug.cgi?id=1874621#c5.
+#
+# [-]  The project directory is mounted as read-only in order to prevent changes to the sources.
+#      Also 'Z' flag is specified in order to make podman set the correct context inside the container,
+#      more details at https://docs.podman.io/en/latest/markdown/podman-run.1.html (search keyword ':Z')
+
 set -x
 set -e
 
+readonly SCRIPT_PATH=$(dirname "$(realpath "$0")")
+readonly PROJECT_PATH=$(realpath "${SCRIPT_PATH}/..")
+readonly OUT_DIR="${PROJECT_PATH}/_out"
+readonly BUILD_DIR="${PROJECT_PATH}/build"
+
+readonly GO_ALPINE_IMAGE="golang:1.17.7-alpine3.15"
+readonly CONTAINER_GO_BUILD_CACHE_DIR="/root/.cache/go-build"
+readonly CONTAINER_SRC_DIR="/go/src"
+readonly CONTAINER_OUT_DIR="/go/bin"
+readonly BINARY_NAME="checkup-framework"
+
+readonly CACHE_VOLUME_NAME="go-build-cache"
+
+readonly IMAGE_NAME="checkup-framework"
+TAG=${TAG:-latest}
+
 CRI="${CRI:-podman}"
 
-$CRI image build . -t checkup-launcher:latest
+[ -d "${OUT_DIR}" ] && \
+  rm -vrf ${OUT_DIR}/*
+
+$CRI volume inspect ${CACHE_VOLUME_NAME} >> /dev/null || \
+  $CRI volume create ${CACHE_VOLUME_NAME}
+
+mkdir -p ${OUT_DIR}
+
+$CRI run -it --rm \
+  --volume ${CACHE_VOLUME_NAME}:${CONTAINER_GO_BUILD_CACHE_DIR} \
+  --volume ${OUT_DIR}:${CONTAINER_OUT_DIR} \
+  --volume ${PROJECT_PATH}:${CONTAINER_SRC_DIR}:ro,Z \
+  --workdir ${CONTAINER_SRC_DIR} \
+  ${GO_ALPINE_IMAGE} \
+  go build -v -o "${CONTAINER_OUT_DIR}/${BINARY_NAME}" ./cmd
+
+$CRI image build ${OUT_DIR} \
+  --file ${BUILD_DIR}/Dockerfile \
+  --tag "${IMAGE_NAME}:${TAG}" \

--- a/checkups/echo/manifests/echo-checkup-framework-job.yaml
+++ b/checkups/echo/manifests/echo-checkup-framework-job.yaml
@@ -12,7 +12,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: checkup-launcher
-          image: registry:5000/checkup-launcher:latest
+          image: registry:5000/checkup-framework:latest
           env:
           - name: CONFIGMAP_NAMESPACE
             value: k8s-checkup-framework


### PR DESCRIPTION
Currently the framework image is used both for building
the binary and as the actual artifact.
Eventually we end up with large framework image that includes
other packages it doesn't need.

Building the framework binary is performed by using alpine-go
image directly.
The framework image is built from alpine image and includes
only the binary.
In order to reduce build time and provide better development experience,
go runtime cache is saved to a persistent volume, that is being reused
on each iteration.

Signed-off-by: Or Mergi <ormergi@redhat.com>
