### PR TITLE
Fix build instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 # Checkup's Launcher
 ## Build Instructions
 ```bash
-# build checkup-framework image
-$ build/build-image
+# build checkup-framework's image
+$ ./build/build-image
 
-# override CRI to use different container runtime
-$ CRI=docker 
-$ build/build-image
+# override CRI to use a different container runtime
+$ CRI=docker ./build/build-image
 ```
 
 ## Deployment Instructions
 1. Push the built image to a registry of your choice.
-2. See example manifest under `checkups/echo/manifests/echo-checkup-framework-job.yaml`.
+2. See example manifest under:
+`checkups/echo/manifests/echo-checkup-framework-job.yaml`.


### PR DESCRIPTION
The build instructions lacked './' before the build scripts.

Signed-off-by: Orel Misan <omisan@redhat.com>