### PR TITLE
Add minimal Setup and tear-down of the checkup's workspace

### DIFF
--- a/checkups/echo/manifests/echo-checkup-framework-job.yaml
+++ b/checkups/echo/manifests/echo-checkup-framework-job.yaml
@@ -2,16 +2,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: checkup-launcher
+  name: checkup-framework
   namespace: k8s-checkup-framework
 spec:
   backoffLimit: 0
   template:
     spec:
-      serviceAccount: checkup-launcher-sa
+      serviceAccount: checkup-framework-sa
       restartPolicy: Never
       containers:
-        - name: checkup-launcher
+        - name: checkup-framework
           image: registry:5000/checkup-framework:latest
           env:
           - name: CONFIGMAP_NAMESPACE

--- a/cmd/checkup-launcher.go
+++ b/cmd/checkup-launcher.go
@@ -38,6 +38,12 @@ func main() {
 	}
 
 	logCheckupSpec(checkupSpec)
+
+	checkupWorkspace := checkup.NewWorkspace(clientset, checkupSpec)
+
+	if err := checkupWorkspace.Setup(); err != nil {
+		log.Fatalf("Failed to setup checkup workspace: %v\n", err.Error())
+	}
 }
 
 func createK8sClientSet() (*kubernetes.Clientset, error) {

--- a/cmd/checkup-launcher.go
+++ b/cmd/checkup-launcher.go
@@ -44,6 +44,10 @@ func main() {
 	if err := checkupWorkspace.Setup(); err != nil {
 		log.Fatalf("Failed to setup checkup workspace: %v\n", err.Error())
 	}
+
+	if err := checkupWorkspace.Teardown(); err != nil {
+		log.Fatalf("Failed to teardown checkup workspace: %v\n", err.Error())
+	}
 }
 
 func createK8sClientSet() (*kubernetes.Clientset, error) {

--- a/hack/run-echo-checkup
+++ b/hack/run-echo-checkup
@@ -4,10 +4,10 @@ set -e
 
 FRAMEWORK_NAMESPACE="k8s-checkup-framework"
 CONFIG_MAP_NAME="echo-checkup-example-config"
-CHECKUP_LAUNCHER_JOB_NAME="checkup-launcher"
+CHECKUP_FRAMEWORK_JOB_NAME="checkup-framework"
 
 USER_CONFIG_MANIFEST_FILE="./checkups/echo/manifests/echo-checkup-config-example.yaml"
-CHECKUP_LAUNCHER_JOB_MANIFEST_FILE="./checkups/echo/manifests/echo-checkup-framework-job.yaml"
+CHECKUP_FRAMEWORK_JOB_MANIFEST_FILE="./checkups/echo/manifests/echo-checkup-framework-job.yaml"
 
 WAIT_PERIOD_SEC=5
 
@@ -15,27 +15,27 @@ kubectl version
 
 echo "Creating echo ConfigMap..."
 kubectl apply -f $USER_CONFIG_MANIFEST_FILE
-echo "Starting the checkup-launcher..."
-kubectl apply -f $CHECKUP_LAUNCHER_JOB_MANIFEST_FILE
+echo "Starting the checkup-framework..."
+kubectl apply -f $CHECKUP_FRAMEWORK_JOB_MANIFEST_FILE
 
-echo "Wait for checkup-launcher to finish or fail"
+echo "Wait for checkup-framework to finish or fail"
 while true; do
-  if kubectl wait --for=condition=complete --timeout=0 job.batch/${CHECKUP_LAUNCHER_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
+  if kubectl wait --for=condition=complete --timeout=0 job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
     break
   fi
 
-  if kubectl wait --for=condition=failed --timeout=0 job.batch/${CHECKUP_LAUNCHER_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
+  if kubectl wait --for=condition=failed --timeout=0 job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
     break
   fi
 
   sleep $WAIT_PERIOD_SEC
 done
 
-echo "checkup-launcher logs:"
-kubectl logs job.batch/${CHECKUP_LAUNCHER_JOB_NAME} -n $FRAMEWORK_NAMESPACE
+echo "checkup-framework logs:"
+kubectl logs job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE
 
-echo "Removing the checkup-launcher..."
-kubectl delete -f $CHECKUP_LAUNCHER_JOB_MANIFEST_FILE
+echo "Removing the checkup-framework..."
+kubectl delete -f $CHECKUP_FRAMEWORK_JOB_MANIFEST_FILE
 
 echo "Results:"
 kubectl get configmap $CONFIG_MAP_NAME -n $FRAMEWORK_NAMESPACE -o yaml

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -45,6 +45,9 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "serviceaccounts" ]
     verbs: [ "get", "list", "create" ]
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "list", "create" ]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -42,6 +42,10 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
     verbs: [ "get", "list", "create", "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "serviceaccounts" ]
+    verbs: [ "get", "list", "create" ]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: checkup-launcher-sa
+  name: checkup-framework-sa
   namespace: k8s-checkup-framework
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,11 +23,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: configmap-reader-checkup-launcher-sa
+  name: configmap-reader-checkup-framework-sa
   namespace: k8s-checkup-framework
 subjects:
   - kind: ServiceAccount
-    name: checkup-launcher-sa
+    name: checkup-framework-sa
     namespace: k8s-checkup-framework
 roleRef:
   kind: Role

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -47,8 +47,10 @@ rules:
     verbs: [ "get", "list", "create" ]
   - apiGroups: [ "" ]
     resources: [ "configmaps" ]
+    verbs: [ "get", "list", "create", "update", "patch" ]
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources: [ "roles" ]
     verbs: [ "get", "list", "create" ]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -49,7 +49,7 @@ rules:
     resources: [ "configmaps" ]
     verbs: [ "get", "list", "create", "update", "patch" ]
   - apiGroups: [ "rbac.authorization.k8s.io" ]
-    resources: [ "roles" ]
+    resources: [ "roles", "rolebindings" ]
     verbs: [ "get", "list", "create" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -33,4 +33,26 @@ roleRef:
   kind: Role
   name: configmap-reader
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: checkup-framework
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "namespaces" ]
+    verbs: [ "get", "list", "create" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: checkup-framework-checkup-framework-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: checkup-framework
+subjects:
+  - kind: ServiceAccount
+    name: checkup-framework-sa
+    namespace: k8s-checkup-framework
 ...

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -41,7 +41,7 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
-    verbs: [ "get", "list", "create" ]
+    verbs: [ "get", "list", "create", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/checkup/workspace.go
+++ b/pkg/checkup/workspace.go
@@ -1,0 +1,51 @@
+package checkup
+
+import (
+	"context"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Workspace struct {
+	clientset *kubernetes.Clientset
+	spec      *Spec
+	namespace string
+}
+
+func NewWorkspace(clientset *kubernetes.Clientset, spec *Spec) *Workspace {
+	return &Workspace{
+		clientset: clientset,
+		spec:      spec,
+	}
+}
+
+func (w *Workspace) Setup() error {
+	if err := w.createNamespace(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *Workspace) createNamespace() error {
+	const namespacePrefix = "checkup-"
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: namespacePrefix,
+		},
+	}
+
+	createdNamespace, err := w.clientset.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	w.namespace = createdNamespace.Name
+	log.Printf("Successfuly created namesapce: %q\n", w.namespace)
+
+	return nil
+}

--- a/pkg/checkup/workspace.go
+++ b/pkg/checkup/workspace.go
@@ -30,6 +30,14 @@ func (w *Workspace) Setup() error {
 	return nil
 }
 
+func (w *Workspace) Teardown() error {
+	if err := w.deleteNamespace(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (w *Workspace) createNamespace() error {
 	const namespacePrefix = "checkup-"
 
@@ -46,6 +54,17 @@ func (w *Workspace) createNamespace() error {
 
 	w.namespace = createdNamespace.Name
 	log.Printf("Successfuly created namesapce: %q\n", w.namespace)
+
+	return nil
+}
+
+func (w *Workspace) deleteNamespace() error {
+	if err := w.clientset.CoreV1().Namespaces().Delete(context.Background(), w.namespace, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	log.Printf("Successfuly deleted namesapce: %q\n", w.namespace)
+	w.namespace = ""
 
 	return nil
 }


### PR DESCRIPTION
This adds a minimal setup of the checkup's workspace which includes:
1. Create a namespace.
2. Create a ServiceAccount.
3. Create a ConfigMap to hold the checkup's results.
4. Create a Role and RoleBinding to allow the checkup to write to the results ConfigMap.

This also adds a minimal tear-down of the checkup's workspace which includes removing the created Namespace.

This is loosely based on work done on [PR#7](https://github.com/orelmisan/k8s-checkup-framework/pull/7) by @ormergi.