### PR TITLE
Watch checkup job

### DIFF
--- a/checkups/echo/entrypoint
+++ b/checkups/echo/entrypoint
@@ -11,7 +11,7 @@
 set -e
 
 date +"%Y-%m-%dT%H:%M:%S%:z" | tr -d "\n"
-echo " Starting echo checkup"
+echo " *** Starting echo checkup ***"
 
 # Check mandatory environment variables supplied by the framework
 if [ -z "$RESULT_CONFIGMAP_NAMESPACE" ]; then

--- a/checkups/echo/manifests/echo-checkup-framework-job.yaml
+++ b/checkups/echo/manifests/echo-checkup-framework-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: checkup-launcher
+  name: checkup-framework
   namespace: k8s-checkup-framework
 spec:
   backoffLimit: 0
@@ -11,7 +11,7 @@ spec:
       serviceAccount: checkup-framework-sa
       restartPolicy: Never
       containers:
-        - name: checkup-launcher
+        - name: checkup-framework
           image: registry:5000/checkup-framework:latest
           env:
           - name: CONFIGMAP_NAMESPACE

--- a/hack/run-echo-checkup
+++ b/hack/run-echo-checkup
@@ -19,12 +19,14 @@ echo "Starting the checkup-framework..."
 kubectl apply -f $CHECKUP_FRAMEWORK_JOB_MANIFEST_FILE
 
 echo "Waiting for checkup-framework to finish..."
+job_failed=false
 while true; do
   if kubectl wait --for=condition=complete --timeout=0 job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
     break
   fi
 
   if kubectl wait --for=condition=failed --timeout=0 job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
+    job_failed=true
     break
   fi
 
@@ -46,3 +48,8 @@ kubectl delete -f $USER_CONFIG_MANIFEST_FILE
 echo
 date +"%Y-%m-%dT%H:%M:%S%:z" | tr -d "\n"
 echo " *** Done ***"
+
+if [ "$job_failed" == "true" ]; then
+  echo "FATAL: error occurred while running echo checkup" 1>&2
+  exit 1
+fi

--- a/hack/run-echo-checkup
+++ b/hack/run-echo-checkup
@@ -4,10 +4,10 @@ set -e
 
 FRAMEWORK_NAMESPACE="k8s-checkup-framework"
 CONFIG_MAP_NAME="echo-checkup-example-config"
-CHECKUP_LAUNCHER_JOB_NAME="checkup-launcher"
+CHECKUP_FRAMEWORK_JOB_NAME="checkup-framework"
 
 USER_CONFIG_MANIFEST_FILE="./checkups/echo/manifests/echo-checkup-config-example.yaml"
-CHECKUP_LAUNCHER_JOB_MANIFEST_FILE="./checkups/echo/manifests/echo-checkup-framework-job.yaml"
+CHECKUP_FRAMEWORK_JOB_MANIFEST_FILE="./checkups/echo/manifests/echo-checkup-framework-job.yaml"
 
 WAIT_PERIOD_SEC=5
 
@@ -15,27 +15,27 @@ kubectl version
 
 echo "Creating echo ConfigMap..."
 kubectl apply -f $USER_CONFIG_MANIFEST_FILE
-echo "Starting the checkup-launcher..."
-kubectl apply -f $CHECKUP_LAUNCHER_JOB_MANIFEST_FILE
+echo "Starting the checkup-framework..."
+kubectl apply -f $CHECKUP_FRAMEWORK_JOB_MANIFEST_FILE
 
-echo "Wait for checkup-launcher to finish or fail"
+echo "Waiting for checkup-framework to finish..."
 while true; do
-  if kubectl wait --for=condition=complete --timeout=0 job.batch/${CHECKUP_LAUNCHER_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
+  if kubectl wait --for=condition=complete --timeout=0 job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
     break
   fi
 
-  if kubectl wait --for=condition=failed --timeout=0 job.batch/${CHECKUP_LAUNCHER_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
+  if kubectl wait --for=condition=failed --timeout=0 job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE 2>/dev/null; then
     break
   fi
 
   sleep $WAIT_PERIOD_SEC
 done
 
-echo "checkup-launcher logs:"
-kubectl logs job.batch/${CHECKUP_LAUNCHER_JOB_NAME} -n $FRAMEWORK_NAMESPACE
+echo "checkup-framework logs:"
+kubectl logs job.batch/${CHECKUP_FRAMEWORK_JOB_NAME} -n $FRAMEWORK_NAMESPACE
 
-echo "Removing the checkup-launcher..."
-kubectl delete -f $CHECKUP_LAUNCHER_JOB_MANIFEST_FILE
+echo "Removing the checkup-framework..."
+kubectl delete -f $CHECKUP_FRAMEWORK_JOB_MANIFEST_FILE
 
 echo "Results:"
 kubectl get configmap $CONFIG_MAP_NAME -n $FRAMEWORK_NAMESPACE -o yaml

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -52,6 +52,15 @@ rules:
   - list
   - create
   - delete
+  - watch
+- apiGroups: [ "" ]
+  resources: [ "pods" ]
+  verbs:
+  - get
+  - list
+- apiGroups: [ "" ]
+  resources: [ "pods/log" ]
+  verbs: [ "get" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/checkup/watch.go
+++ b/pkg/checkup/watch.go
@@ -1,0 +1,66 @@
+package checkup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+const JobNameLabel = "job-name"
+
+func WaitForJobToComplete(client *kubernetes.Clientset, jobName, jobNamespace string, timeout time.Duration) (*batchv1.Job, error) {
+	jobLabel := fmt.Sprintf("%s=%s", JobNameLabel, jobName)
+	jobWatcher, err := client.BatchV1().Jobs(jobNamespace).Watch(context.Background(), metav1.ListOptions{LabelSelector: jobLabel})
+	if err != nil {
+		return nil, err
+	}
+
+	completedJob, err := waitForJobCompletionEvent(timeout, jobWatcher)
+	if err != nil {
+		return nil, err
+	}
+
+	return completedJob, nil
+}
+
+func waitForJobCompletionEvent(timeout time.Duration, watcher k8swatch.Interface) (*batchv1.Job, error) {
+	const timeoutErrorMsg = "timeout reached"
+	timeoutTimer := time.NewTimer(timeout)
+	eventsCh := watcher.ResultChan()
+	defer watcher.Stop()
+	for {
+		select {
+		case <-timeoutTimer.C:
+			return nil, fmt.Errorf("%s", timeoutErrorMsg)
+		case event := <-eventsCh:
+			job, ok := event.Object.(*batchv1.Job)
+			if !ok {
+				continue
+			}
+
+			log.Printf("got job event:\n")
+			raw, _ := json.MarshalIndent(job.Status, "", " ")
+			log.Println(string(raw))
+
+			if isJobFailedOrCompleted(job) {
+				return job, nil
+			}
+		}
+	}
+}
+
+func isJobFailedOrCompleted(job *batchv1.Job) bool {
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobComplete || condition.Type == batchv1.JobFailed {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Currently the checkup-framework launches a checkup and
exit,in order to do proper teardown, dumping logs and provide
meaningful feedback regarding the checkup status,
it is necessary to watch the Job status during execution,
wait for it to finish.

Signed-off-by: Or Mergi <ormergi@redhat.com>
