### PR TITLE
Add framework e2e test automation script

### DIFF
--- a/checkups/echo/build-image
+++ b/checkups/echo/build-image
@@ -3,6 +3,13 @@
 set -x
 set -e
 
+readonly SCRIPT_PATH=$(dirname "$(realpath "$0")")
+
 CRI="${CRI:-podman}"
 
-$CRI image build . -t echo-checkup:latest
+readonly IMAGE_NAME="echo-checkup"
+TAG=${TAG:-latest}
+
+$CRI image build ${SCRIPT_PATH} \
+  --file ${SCRIPT_PATH}/Dockerfile \
+  --tag "${IMAGE_NAME}:${TAG}"

--- a/hack/framework-e2e-test
+++ b/hack/framework-e2e-test
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+readonly SCRIPT_PATH=$(dirname "$(realpath "$0")")
+readonly PROJECT_PATH=$(realpath "$SCRIPT_PATH/..")
+
+readonly FRAMEWORK_IMAGE="checkup-framework"
+readonly FRAMEWORK_TAG="latest"
+
+readonly ECHO_IMAGE="echo-checkup"
+readonly ECHO_TAG="latest"
+
+CRI="${CRI:-podman}"
+REGISTRY="${REGISTRY:-localhost:5000}"
+
+# build framework image
+CRI="$CRI" TAG="$FRAMEWORK_TAG" $PROJECT_PATH/build/build-image
+
+$CRI tag "${FRAMEWORK_IMAGE}:${FRAMEWORK_TAG}" "${REGISTRY}/${FRAMEWORK_IMAGE}:${FRAMEWORK_TAG}"
+$CRI push "${REGISTRY}/${FRAMEWORK_IMAGE}:${FRAMEWORK_TAG}"
+
+# build echo checkup image
+CRI="$CRI" TAG="$ECHO_TAG" $PROJECT_PATH/checkups/echo/build-image
+
+$CRI tag "${ECHO_IMAGE}:${ECHO_TAG}" "${REGISTRY}/${ECHO_IMAGE}:${ECHO_TAG}"
+$CRI push "${REGISTRY}/${ECHO_IMAGE}:${ECHO_TAG}"
+
+trap $PROJECT_PATH/hack/remove-framework EXIT
+$PROJECT_PATH/hack/deploy-framework
+$PROJECT_PATH/hack/run-echo-checkup

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -65,3 +65,20 @@ subjects:
 - kind: ServiceAccount
   name: checkup-framework-sa
   namespace: k8s-checkup-framework
+    Add framework e2e automation script
+    
+    Currently there is no automation for running
+    a checkup through the framework including building
+    the images of the framework and the checkup.
+    
+    In order to shorten iteration time and get quick
+    feedback whether this commit introduce hack/framework-e2e
+    which automate the following flow:
+    - checkup-framework build
+    - echo checkup build
+    - framework deployment
+    - running the echo checkup with the framework
+    - teardown
+
+    Also, echo checkup build-image script is changed
+    to enable running it from any directory.


### PR DESCRIPTION
Currently there is no automation for running
a checkup through the framework including building
the images of the framework and the checkup.

In order to shorten iteration time and get quick
feedback whether this commit introduce hack/framework-e2e
which automate the following flow:
- checkup-framework build
- echo checkup build
- framework deployment
- running the echo checkup with the framework
- teardown

Signed-off-by: Or Mergi <ormergi@redhat.com>
