### PR TITLE
Perform checkup workspace tear-down

### DIFF
--- a/cmd/checkup-launcher.go
+++ b/cmd/checkup-launcher.go
@@ -40,6 +40,13 @@ func main() {
 	if err := workspace.SetupCheckupWorkspace(clientset); err != nil {
 		log.Fatalf("Failed to setup the checkup's environment: %v", err)
 	}
+
+	defer func() {
+		if err := workspace.Teardown(clientset); err != nil {
+			log.Printf("Failed to tear-down the checkup workspace: %v", err)
+		}
+	}()
+
 	jobErr := workspace.StartAndWaitCheckupJob(clientset)
 
 	checkupJob := workspace.Job()

--- a/manifests/k8s-checkup-framework.yaml
+++ b/manifests/k8s-checkup-framework.yaml
@@ -21,6 +21,7 @@ rules:
   - get
   - list
   - create
+  - delete
 - apiGroups: [ "" ]
   resources: [ "serviceaccounts" ]
   verbs:

--- a/pkg/checkup/workspace.go
+++ b/pkg/checkup/workspace.go
@@ -352,3 +352,22 @@ func (w *workspace) StartAndWaitCheckupJob(client *kubernetes.Clientset) error {
 
 	return nil
 }
+
+func (w *workspace) Teardown(client *kubernetes.Clientset) error {
+	if err := w.deleteNamespace(client); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *workspace) deleteNamespace(client *kubernetes.Clientset) error {
+	if err := client.CoreV1().Namespaces().Delete(context.Background(), w.namespace.Name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	log.Printf("Successfuly deleted namesapce: %q\n", w.namespace.Name)
+	w.namespace = nil
+
+	return nil
+}


### PR DESCRIPTION
This adds the capability to remove the checkup's Namespace.

Signed-off-by: Orel Misan <omisan@redhat.com>