### PR TITLE
Move the call to logCheckupSpec()

### DIFF
--- a/cmd/checkup-launcher.go
+++ b/cmd/checkup-launcher.go
@@ -36,6 +36,8 @@ func main() {
 		log.Fatalf("Failed to create checkup spec: %v\n", err.Error())
 	}
 
+	logCheckupSpec(checkupSpec)
+
 	workspace := checkup.NewCheckupWorkspace(checkupSpec)
 	if err := workspace.SetupCheckupWorkspace(clientset); err != nil {
 		log.Fatalf("Failed to setup the checkup's environment: %v", err)
@@ -43,7 +45,6 @@ func main() {
 	jobErr := workspace.StartAndWaitCheckupJob(clientset)
 
 	checkupJob := workspace.Job()
-	logCheckupSpec(checkupSpec)
 	if err := logCheckupJobLogs(clientset, checkupJob.Namespace); err != nil {
 		log.Printf("Failed to dump checkup job logs: %v", err)
 	}


### PR DESCRIPTION
This moves the call to logCheckupSpec() before creating a new workspace.

Signed-off-by: Orel Misan <omisan@redhat.com>